### PR TITLE
make storageClassName default to the default storage class

### DIFF
--- a/charts/statping/templates/pvc.yaml
+++ b/charts/statping/templates/pvc.yaml
@@ -7,10 +7,12 @@ metadata:
   labels: {{ include "statping.labels" . | nindent 4 }}
     app.kubernetes.io/component: statping
 spec:
+  {{- if .Values.persistence.storageClassName }}
   storageClassName: {{ .Values.persistence.storageClassName | quote }}
+  {{- end }}
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  {{- end -}}
+{{- end -}}

--- a/charts/statping/values.yaml
+++ b/charts/statping/values.yaml
@@ -45,8 +45,8 @@ persistence:
   enabled: true
   accessMode: ReadWriteOnce
   size: 10Gi
-  storageClassName: "do-block-storage"
-#  existingClaim:
+  # storageClassName: "do-block-storage"
+  # existingClaim:
 
 ingress:
   # ingress.enabled -- Enable ingress


### PR DESCRIPTION
Ran into an issue when deploying this chart for the first time.  The default storageClassName "do-block-storage" doesn't exist on my cluster.  Having the chart default to the default storage class simplifies an initial deployment, while still retaining flexibility.